### PR TITLE
Read/write JSON files with fetched data, fix data arrays being empty due to asynchronous requests

### DIFF
--- a/Parse/DataHandler.swift
+++ b/Parse/DataHandler.swift
@@ -1,0 +1,53 @@
+//
+//  CacheJSON.swift
+//  ShuttleTrackeriOS
+//
+//  Created by Matt Czyr on 10/4/18.
+//  Copyright © 2018 WTG. All rights reserved.
+//
+
+import Foundation
+
+// Returns whether or not a file with the provided filename exists in
+// the application's documents directory. If the file does not exist,
+// the data will need to be fetched and written.
+func fileExists(filename: String) -> Bool {
+    if let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+        let fileURL = dir.appendingPathComponent(filename)
+        return FileManager.default.fileExists(atPath: fileURL.absoluteString)
+    }
+    return false
+}
+
+// Write JSON data to the file at the relative file path provided
+// in the application's documents directory.
+func writeJSON(filename: String, data: String) {
+    if let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+        let fileURL = dir.appendingPathComponent(filename)
+        do {
+            try data.write(to: fileURL, atomically: false, encoding: .utf8)
+            print("Finished writing JSON data to \(filename)")
+            print("Absolute filepath: \(fileURL)")
+        } catch let error as NSError {
+            print("Error writing JSON data to \(filename):")
+            print(error)
+        }
+    }
+}
+
+// Reads JSON data from the file and returns as a String. In the case of
+// an error while writing to the file, returns an empty String.
+func readJSON(filename: String) -> String {
+    if let dir = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first {
+        let fileURL = dir.appendingPathComponent(filename)
+        do {
+            let routeText = try String(contentsOf: fileURL, encoding: .utf8)
+            print("Finished reading JSON data from \(filename)")
+            return routeText
+        } catch let error as NSError {
+            print("Error reading JSON data from \(filename):")
+            print(error)
+        }
+    }
+    return ""
+}

--- a/Parse/Point.swift
+++ b/Parse/Point.swift
@@ -9,20 +9,20 @@
 import Foundation
 
 struct Point {
-    
+
     var latitude: Double
     var longitude: Double
     
+    // Initialize point data
     init(latitude: Double, longitude: Double) {
         self.latitude = latitude
         self.longitude = longitude
     }
-    
 
 }
 
-extension Point:CustomStringConvertible{
-    var description:String{
+extension Point:CustomStringConvertible {
+    var description:String {
         return """
                  (latitude \(self.latitude), longitude \(self.longitude))\n
                  """

--- a/Parse/Route.swift
+++ b/Parse/Route.swift
@@ -1,5 +1,5 @@
 //
-//  route.swift
+//  Route.swift
 //  ShuttleTrackeriOS
 //
 //  Created by Andrew Qu on 9/26/18.
@@ -21,15 +21,12 @@ struct Route {
     var updated = ""
     var width = 0
     
+    // Initialize route data from JSON dictionary
     init?(json: NSDictionary) {
-        //need to add the points to the route
+        // Need to add the points to the route
         var pointsList:[Point] = [];
-        
-        //for each different value of each route
         for (key, value) in json {
             switch key as? NSString {
-                
-            //catching different variables for a route
             case "color":
                 self.color = (value as! String)
             case "created":
@@ -49,8 +46,8 @@ struct Route {
             case "width":
                 self.width = (value as! Int)
             case "points":
-                //need to parse the coordinates separately since
-                //nested dictionary inside a dictionary
+                // Need to parse the coordinates separately since
+                // nested dictionary inside a dictionary
                 for loc in (value as! NSArray) {
                     var lat: Double = 0
                     var long: Double = 0
@@ -61,15 +58,15 @@ struct Route {
                             long = piece.value as! Double
                         }
                     }
-                    //append the points to the array
+                    // Append the points to the array
                     pointsList.append(Point(latitude: lat, longitude: long))
                 }
             default:
-                //should never go off
+                // This should never happen
                 print("\(key)")
             }
         }
-        //points set at the end
+        // Set the points at the end
         self.points = pointsList
         print("Finished JSON initialization for route \(self.id)")
     }
@@ -77,28 +74,27 @@ struct Route {
 
     
 }
-extension Route:CustomStringConvertible{
-    var description: String{
+extension Route:CustomStringConvertible {
+    var description: String {
         return  """
-                  Color: \(self.color)
-                  Created: \(self.created)
-                  Description: \(self.desc)
-                  Enabled: \(self.enabled)
-                  ID: \(self.id)
-                  Name: \(self.name)
-                  Points: \(self.points)
-                  Stop IDs: \(self.stop_ids)
-                  Updated: \(self.updated)
-                  Width: \(self.width)
-                  """
+                Color: \(self.color)
+                Created: \(self.created)
+                Description: \(self.desc)
+                Enabled: \(self.enabled)
+                ID: \(self.id)
+                Name: \(self.name)
+                Points: \(self.points)
+                Stop IDs: \(self.stop_ids)
+                Updated: \(self.updated)
+                Width: \(self.width)
+                """
     }
 }
 
-func fetchRoutes() -> [Route] {
-    // The URL
-    let address = URL(string: "https://shuttles.rpi.edu/routes")!
-    let urlRequest = URLRequest(url: address)
-    
+// Fetches route data from shuttles.rpi.edu/routes and writes it
+// to routes.json in the application's documents directory.
+// Returns a String containing the raw JSON data fetched.
+func fetchRoutes() -> String {
     /*
      TODO:
      
@@ -106,28 +102,45 @@ func fetchRoutes() -> [Route] {
      figure out how to use JSONSerialization with a Data object
      Maybe have to create a struct with the certain format of the JSON?
      Working with NSArray instead of a parsed [String: Any] Dictionary????
-     
      */
-    
-    var routes:[Route] = []
-    let task = URLSession.shared.dataTask(with: urlRequest) {
-        toParse, response, error in
-        guard toParse != nil else { return }
-        let json = try? JSONSerialization.jsonObject(with: toParse!, options: []) as! NSArray
-        
-        // For each route, initialize a new route with the parameters in the unique dic
-        for unique in json! {
-            print("Creating new route...")
-            let r = Route(json:unique as! NSDictionary)
-            print(r!)
-            routes.append(r!)
-            // differentRoutes.append(Route(json:(unique as! NSDictionary))!);
+
+    let urlString = URL(string: "https://shuttles.rpi.edu/routes")
+    let semaphore = DispatchSemaphore(value: 0)
+    var routesData = ""
+    if let url = urlString {
+        let task = URLSession.shared.dataTask(with: url) { (data, response, error) in
+            if error != nil {
+                print(error!)
+            } else {
+                if let usableData = data {
+                    let dataString = String(data: usableData, encoding: .utf8)!
+                    writeJSON(filename: "routes.json", data: dataString)
+                    routesData = dataString
+                    semaphore.signal()
+                }
+            }
         }
+        task.resume()
+        semaphore.wait()
+    }
+    return routesData
+}
+
+// Initializes routes from routes.json if it exists, otherwise will
+// fetch route data and write it to routes.json before returning an
+// array of the routes.
+func initRoutes() -> [Route] {
+    var routes:[Route] = []
+    let file = "routes.json"
+    let dataString = !fileExists(filename: file) ? fetchRoutes() : readJSON(filename: file)
+    let data = dataString.data(using: .utf8)!
+    let json = try? JSONSerialization.jsonObject(with: data, options: []) as! NSArray
+    for unique in json! {
+        print("Creating new route...")
+        let route = Route(json:unique as! NSDictionary)
+        print(route!)
+        routes.append(route!)
     }
     
-    // keep it running when it's done
-    task.resume()
-    
     return routes
-    
 }

--- a/ShuttleTrackeriOS.xcodeproj/project.pbxproj
+++ b/ShuttleTrackeriOS.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		551344E32163098A009618D0 /* Vehicle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 551344E22163098A009618D0 /* Vehicle.swift */; };
 		55BB269E2166C28000BBC615 /* Stop.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BB269D2166C28000BBC615 /* Stop.swift */; };
 		55BB26A2216705BF00BBC615 /* Update.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BB26A1216705BF00BBC615 /* Update.swift */; };
+		55BB26A4216708BC00BBC615 /* DataHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55BB26A3216708BC00BBC615 /* DataHandler.swift */; };
 		928A17AB215C0B7F00A862B2 /* Route.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928A17AA215C0B7F00A862B2 /* Route.swift */; };
 		928A17AD215C0CE800A862B2 /* Point.swift in Sources */ = {isa = PBXBuildFile; fileRef = 928A17AC215C0CE800A862B2 /* Point.swift */; };
 		92A3623321519BF700B7B33B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92A3623221519BF700B7B33B /* AppDelegate.swift */; };
@@ -59,6 +60,7 @@
 		551344E22163098A009618D0 /* Vehicle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Vehicle.swift; sourceTree = "<group>"; };
 		55BB269D2166C28000BBC615 /* Stop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Stop.swift; sourceTree = "<group>"; };
 		55BB26A1216705BF00BBC615 /* Update.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update.swift; sourceTree = "<group>"; };
+		55BB26A3216708BC00BBC615 /* DataHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataHandler.swift; sourceTree = "<group>"; };
 		928A17AA215C0B7F00A862B2 /* Route.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Route.swift; sourceTree = "<group>"; };
 		928A17AC215C0CE800A862B2 /* Point.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Point.swift; sourceTree = "<group>"; };
 		92A3622F21519BF700B7B33B /* ShuttleTrackeriOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ShuttleTrackeriOS.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -105,6 +107,7 @@
 		9217F39E21644762008C847A /* Parse */ = {
 			isa = PBXGroup;
 			children = (
+				55BB26A3216708BC00BBC615 /* DataHandler.swift */,
 				928A17AA215C0B7F00A862B2 /* Route.swift */,
 				928A17AC215C0CE800A862B2 /* Point.swift */,
 				551344E22163098A009618D0 /* Vehicle.swift */,
@@ -320,6 +323,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				55BB26A4216708BC00BBC615 /* DataHandler.swift in Sources */,
 				928A17AD215C0CE800A862B2 /* Point.swift in Sources */,
 				92A3623521519BF700B7B33B /* ViewController.swift in Sources */,
 				55BB26A2216705BF00BBC615 /* Update.swift in Sources */,

--- a/ShuttleTrackeriOS/ViewController.swift
+++ b/ShuttleTrackeriOS/ViewController.swift
@@ -27,10 +27,15 @@ class ViewController: UIViewController {
         mapView.styleURL = MGLStyle.lightStyleURL
         
         // TODO: Right place to be calling this?
-        let vehicles = fetchVehicles()
-        let updates = fetchUpdates()
-        let stops = fetchStops()
-        let routes = fetchRoutes()
+        let vehicles = initVehicles()
+        let updates = initUpdates()
+        let stops = initStops()
+        let routes = initRoutes()
+        
+        print("Initialized \(vehicles.count) vehicles")
+        print("Initialized \(updates.count) updates")
+        print("Initialized \(stops.count) stops")
+        print("Initialized \(routes.count) routes")
         
         allCoordinates = coordinates()
     }


### PR DESCRIPTION
Because our HTTP requests were asynchronous, the data arrays we returned were empty because the data had not been fetched yet. `fetch___()` functions now use semaphores to achieve synchronous HTTP requests.

The `fetch___()` functions have been split into `fetch___()` and `init___()` functions:
- `fetch___()` will retrieve the JSON data from shuttles.rpi.edu/___ and, for routes and stops, will write this data to a file named routes.json or stops.json, respectively, in the app's documents folder. To find the app's documents folder, search the output log for "absolute filepath".
- `init___()` will, for the case of routes and stops, first check if the data already exists in routes.json or stops.json. If so, it will populate an array from the data in the JSON files. If not, it will call `fetch___()` to first write the data. For vehicles and updates, `fetch___()` is always called. This is now the driver function for getting the data arrays and is called instead of `fetch___()` in ViewController.